### PR TITLE
Fix dns_record import

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,12 @@ resource freeipa_host "bar" {
 Usage
 ----------------------
 
+
+Import
+------
+
+DNS records can be imported using the record name and the zone name from <record_name>/<zone_name>
+
+```
+$ terraform import freeipa_dns_record.foo foo/example.tld.
+```

--- a/freeipa/resource_freeipa_dns_record.go
+++ b/freeipa/resource_freeipa_dns_record.go
@@ -207,11 +207,48 @@ func resourceFreeIPADNSRecordRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if res.Result.Arecord != nil {
+		d.Set("type", "A")
 		d.Set("records", *res.Result.Arecord)
 	}
 
+	if res.Result.Aaaarecord != nil {
+		d.Set("type", "AAAA")
+		d.Set("records", *res.Result.Aaaarecord)
+	}
+
+	if res.Result.Cnamerecord != nil {
+		d.Set("type", "CNAME")
+		d.Set("records", *res.Result.Cnamerecord)
+	}
+
+	if res.Result.Mxrecord != nil {
+		d.Set("type", "MX")
+		d.Set("records", *res.Result.Mxrecord)
+	}
+
+	if res.Result.Nsrecord != nil {
+		d.Set("type", "NS")
+		d.Set("records", *res.Result.Nsrecord)
+	}
+
+	if res.Result.Ptrrecord != nil {
+		d.Set("type", "PTR")
+		d.Set("records", *res.Result.Ptrrecord)
+	}
+
 	if res.Result.Srvrecord != nil {
+		d.Set("type", "SRV")
 		d.Set("records", *res.Result.Srvrecord)
+	}
+
+	if res.Result.Txtrecord != nil {
+		d.Set("type", "TXT")
+		d.Set("records", *res.Result.Txtrecord)
+	}
+
+	if res.Result.Sshfprecord != nil {
+		d.Set("type", "SSHFP")
+		d.Set("records", *res.Result.Sshfprecord)
 	}
 
 	if res.Result.Dnsttl != nil {
@@ -280,10 +317,14 @@ func resourceFreeIPADNSRecordDelete(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceFreeIPADNSRecordImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	log.Printf("[INFO] Importing DNS Record: %s", d.Id())
+	idnsname, dnszoneidnsname := splitID(d.Id())
 
-	d.SetId(d.Id())
-	d.Set("idnsname", d.Id())
+	d.SetId(fmt.Sprintf("%s.%s", idnsname, dnszoneidnsname))
+
+	d.Set("idnsname", idnsname)
+	d.Set("dnszoneidnsname", dnszoneidnsname)
+
+	log.Printf("[INFO] Importing DNS Record `%s` in zone `%s`.", idnsname, dnszoneidnsname)
 
 	err := resourceFreeIPADNSRecordRead(d, meta)
 	if err != nil {

--- a/freeipa/util.go
+++ b/freeipa/util.go
@@ -1,0 +1,12 @@
+package freeipa
+
+import (
+	"strings"
+)
+
+func splitID(id string) (a, b string) {
+	if strings.Contains(id, "/") {
+		return id[0:strings.Index(id, "/")], id[strings.Index(id, "/")+1:]
+	}
+	return "", id
+}

--- a/freeipa/util_test.go
+++ b/freeipa/util_test.go
@@ -1,0 +1,23 @@
+package freeipa
+
+import (
+	"testing"
+)
+
+var idTests = []struct {
+	id         string
+	zoneName   string
+	resourceID string
+}{
+	{"foo", "foo", ""},
+	{"foo/example.tld", "example.tld", "foo"},
+}
+
+func TestSplitId(t *testing.T) {
+	for _, tt := range idTests {
+		resourceID, zoneName := splitID(tt.id)
+		if zoneName != tt.zoneName || resourceID != tt.resourceID {
+			t.Errorf("splitId(%s) => [%s, %s]) want [%s, %s]", tt.id, resourceID, zoneName, tt.resourceID, tt.zoneName)
+		}
+	}
+}


### PR DESCRIPTION
When importing a DNS record, we must provide both the record name and its zone. With this PR, I add the ability to pass both of these information to the import function.