### PR TITLE
Support http.ProxyFromEnvironment for troubleshooting

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -119,6 +119,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	p.client, err = freeipa.Connect(
 		host,
 		&http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: insecureSkipVerify,
 			},


### PR DESCRIPTION
When troubleshooting it is very useful to direct all HTTP requests from Terraform providers through a proxy, such as mitmproxy.  

This change makes this provider honour the HTTP_PROXY and HTTPS_PROXY environment variables as per https://pkg.go.dev/net/http#ProxyFromEnvironment